### PR TITLE
Fix bug in utils_icarl.py

### DIFF
--- a/iCaRL-Tensorflow/utils_icarl.py
+++ b/iCaRL-Tensorflow/utils_icarl.py
@@ -26,7 +26,7 @@ def reading_data_and_preparing_network(files_from_cl, gpu, itera, batch_size, tr
     loss_class = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(labels=label_batch_one_hot, logits=scores))
     
     ### Initilization
-    params = dict(cPickle.load(open(save_path+'model-iteration'+str(nb_cl)+'-%i.pickle' % itera)), 'rb')
+    params = dict(cPickle.load(open(save_path+'model-iteration'+str(nb_cl)+'-%i.pickle' % itera, 'rb')))
     inits  = utils_resnet.get_weight_initializer(params)
     
     return inits,scores,label_batch,loss_class,file_string_batch,op_feature_map


### PR DESCRIPTION
The access mode argument 'rb' was inside the wrong level of parenthesis.
This was leading to "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte" as the pickle file was being opened in 'r' mode by default